### PR TITLE
Escape special character

### DIFF
--- a/Plutonium/updateMain.bat
+++ b/Plutonium/updateMain.bat
@@ -47,7 +47,7 @@ GOTO:EOF
    REM SET "_strRepl="require("init")(process.argv, global.paths, initLogging).then(() => {      require("plutonium-backend").init();});""
    TYPE main.js | FINDSTR /v %strFind% >> %TMP_OUT%
    ECHO require("init")(process.argv, global.paths, initLogging) >> %TMP_OUT%
-   ECHO         .then(() => { >> %TMP_OUT%
+   ECHO         .then(() =^> { >> %TMP_OUT%
    ECHO                 require("plutonium-backend").init(); >> %TMP_OUT%
    ECHO         }); >> %TMP_OUT%
    MOVE /Y %TMP_OUT% main.js > NUL


### PR DESCRIPTION
Certain special characters in BATCH need to be escaped or the commands wont work correctly. '>' is one of those characters.  In BATCH the escape character is '^'.

Adding this ensures the modifications are done correctly.